### PR TITLE
:wrench: patching gtest to support gcc-4.8

### DIFF
--- a/PatchUtils.cmake
+++ b/PatchUtils.cmake
@@ -6,64 +6,20 @@
 
 function(apply_patch patch where mark)
     if(NOT EXISTS "${mark}")
-        create_patch_cmd(patch_cmd)
-        file(TO_NATIVE_PATH ${patch} patch)
-        file(TO_NATIVE_PATH ${where} where)
-        file(TO_NATIVE_PATH ${mark} mark)
-        message(STATUS "patching: ${patch_cmd} ${where} ${patch}  ${mark}")
-        execute_process(COMMAND "${patch_cmd}" "${where}" "${patch}" "${mark}"
-            RESULT_VARIABLE status)
+        if(NOT Patch_EXECUTABLE)
+          find_package(Patch REQUIRED)
+        endif()
+        file(TO_NATIVE_PATH ${patch} patch_native)
+        get_filename_component(patch_name "${patch}" NAME)
+        message(STATUS "Applying patch: ${patch_name}")
+        execute_process(
+          COMMAND "${Patch_EXECUTABLE}" "-p0" "--input=${patch_native}"
+          WORKING_DIRECTORY "${where}"
+          RESULT_VARIABLE status)
         if(NOT status STREQUAL "0")
             message(FATAL_ERROR "could not apply patch: ${patch} ---> ${where}")
+        else()
+          file(TOUCH "${mark}")
         endif()
     endif()
-endfunction()
-
-
-function(create_patch_cmd filename_output)
-    if(WIN32)
-        set(filename ${CMAKE_BINARY_DIR}/apply_patch.bat)
-        file(WRITE ${filename} "
-echo on
-set srcdir=%1
-set patch=%2
-set mark=%3
-set prev=%cd%
-set stat=0
-if not exist %mark% (
-    if not exist %patch% (
-        exit /b 1
-    )
-    if not exist %srcdir% (
-        exit /b 1
-    )
-    cd %srcdir%
-    patch -p0 < %patch%
-    set stat=%ERRORLEVEL%
-    cd %prev%
-    echo done > %mark%
-)
-exit /b %stat%
-")
-    else()
-        set(filename ${CMAKE_BINARY_DIR}/apply_patch.sh)
-        file(WRITE ${filename} "#!/bin/sh -x
-set -e
-srcdir=$1
-patch=$2
-mark=$3
-if [ ! -f $mark ] ; then
-    if [ ! -f $patch ] ; then
-        echo \"ERROR: patch not found: $patch\"
-        exit 1
-    fi
-    cd $srcdir || exit 1
-    patch -p0 < $patch || exit 1
-    cd -
-    echo done > $mark
-fi
-exit 0
-")
-    endif()
-    set(${filename_output} ${filename} PARENT_SCOPE)
 endfunction()

--- a/c4Project.cmake
+++ b/c4Project.cmake
@@ -23,6 +23,7 @@ include(c4StaticAnalysis)
 include(PrintVar)
 include(c4CatSources)
 include(c4Doxygen)
+include(PatchUtils)
 
 
 #------------------------------------------------------------------------------
@@ -2773,6 +2774,16 @@ ${ARGN}
                 SET_FOLDER_TARGETS ext gtest gtest_main
                 EXCLUDE_FROM_ALL
                 )
+            # old gcc-4.8 support
+            if((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND
+              (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 4.8) AND
+              (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0))
+                _c4_get_subproject_property(gtest SRC_DIR _gtest_patch_src_dir)
+                apply_patch("${_c4_project_dir}/patchs/gtest_gcc-4.8.patch"
+                  "${_gtest_patch_src_dir}"
+                  "${_gtest_patch_src_dir}/.gtest_gcc-4.8.patch")
+                unset(_gtest_patch_src_dir)
+            endif()
         endif()
     endif()
     if(_DOCTEST)

--- a/patchs/gtest_gcc-4.8.patch
+++ b/patchs/gtest_gcc-4.8.patch
@@ -1,0 +1,97 @@
+Multi-line macros support is not guaranteed with gcc-4.8.
+
+This uses temporary objects to work-arround this limitation, main drawback is
+that compared code is not displayed in message anymore (only "val" placeholders).
+
+--- googletest/include/gtest/gtest.h
++++ googletest/include/gtest/gtest.h
+@@ -2040,6 +2040,80 @@ class TestWithParam : public Test, publi
+ //   ASSERT_LT(i, array_size);
+ //   ASSERT_GT(records.size(), 0) << "There is no record left.";
+ 
++#if __GNUC__ == 4 && __GNUC_MINOR__ >= 8
++/*
++ * multi-line macros support is not guaranteed with gcc-4.8.
++ * This uses temporary objects to work-arround this limitation, main drawback is
++ * that compared code is not displayed in message anymore (only "val" placeholders)
++ */
++
++enum class CompatExpectSelector { EQ, NE, LE, LT, GE, GT };
++
++template <CompatExpectSelector T>
++struct CompatExpect
++{
++  const char *file;
++  int line;
++  ::testing::AssertionResult gtest_ar = AssertionSuccess();
++  ::testing::Message msg;
++
++  CompatExpect(const char *file, int line) : file(file), line(line) {}
++  ~CompatExpect() {
++    if (!gtest_ar)
++      GTEST_MESSAGE_AT_(file, line, gtest_ar.failure_message(), ::testing::TestPartResult::kNonFatalFailure) << msg;
++  }
++
++  template <typename T1, typename T2, CompatExpectSelector SEL = T, typename std::enable_if<SEL == CompatExpectSelector::EQ, int>::type = 0>
++  CompatExpect<T> &operator ()(const T1 &val1, const T2 &val2) {
++    gtest_ar = ::testing::internal::EqHelper::Compare("val1", "val2", val1, val2);
++    return *this;
++  }
++
++  template <typename T1, typename T2, CompatExpectSelector SEL = T, typename std::enable_if<SEL == CompatExpectSelector::NE, int>::type = 0>
++  CompatExpect<T> &operator ()(const T1 &val1, const T2 &val2) {
++    gtest_ar = ::testing::internal::CmpHelperNE("val1", "val2", val1, val2);
++    return *this;
++  }
++
++  template <typename T1, typename T2, CompatExpectSelector SEL = T, typename std::enable_if<SEL == CompatExpectSelector::LE, int>::type = 0>
++  CompatExpect<T> &operator ()(const T1 &val1, const T2 &val2) {
++    gtest_ar = ::testing::internal::CmpHelperLE("val1", "val2", val1, val2);
++    return *this;
++  }
++
++  template <typename T1, typename T2, CompatExpectSelector SEL = T, typename std::enable_if<SEL == CompatExpectSelector::LT, int>::type = 0>
++  CompatExpect<T> &operator ()(const T1 &val1, const T2 &val2) {
++    gtest_ar = ::testing::internal::CmpHelperLT("val1", "val2", val1, val2);
++    return *this;
++  }
++
++  template <typename T1, typename T2, CompatExpectSelector SEL = T, typename std::enable_if<SEL == CompatExpectSelector::GE, int>::type = 0>
++  CompatExpect<T> &operator ()(const T1 &val1, const T2 &val2) {
++    gtest_ar = ::testing::internal::CmpHelperGE("val1", "val2", val1, val2);
++    return *this;
++  }
++
++  template <typename T1, typename T2, CompatExpectSelector SEL = T, typename std::enable_if<SEL == CompatExpectSelector::GT, int>::type = 0>
++  CompatExpect<T> &operator ()(const T1 &val1, const T2 &val2) {
++    gtest_ar = ::testing::internal::CmpHelperGT("val1", "val2", val1, val2);
++    return *this;
++  }
++
++  template <typename T1>
++  CompatExpect &operator << (const T1 &t) {
++    msg << t;
++    return *this;
++  }
++};
++#define EXPECT_EQ ::testing::CompatExpect<::testing::CompatExpectSelector::EQ>{__FILE__,__LINE__}
++#define EXPECT_NE ::testing::CompatExpect<::testing::CompatExpectSelector::NE>{__FILE__,__LINE__}
++#define EXPECT_LE ::testing::CompatExpect<::testing::CompatExpectSelector::LE>{__FILE__,__LINE__}
++#define EXPECT_LT ::testing::CompatExpect<::testing::CompatExpectSelector::LT>{__FILE__,__LINE__}
++#define EXPECT_GE ::testing::CompatExpect<::testing::CompatExpectSelector::GE>{__FILE__,__LINE__}
++#define EXPECT_GT ::testing::CompatExpect<::testing::CompatExpectSelector::GT>{__FILE__,__LINE__}
++
++#else
++
+ #define EXPECT_EQ(val1, val2) \
+   EXPECT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
+ #define EXPECT_NE(val1, val2) \
+@@ -2053,6 +2127,8 @@ class TestWithParam : public Test, publi
+ #define EXPECT_GT(val1, val2) \
+   EXPECT_PRED_FORMAT2(::testing::internal::CmpHelperGT, val1, val2)
+ 
++#endif
++
+ #define GTEST_ASSERT_EQ(val1, val2) \
+   ASSERT_PRED_FORMAT2(::testing::internal::EqHelper::Compare, val1, val2)
+ #define GTEST_ASSERT_NE(val1, val2) \


### PR DESCRIPTION
- Add temporary objects to support multi-line EXPECT_* calls
- only EXPECT_EQ is used in c4core and rapidyaml (but all variants are patched)
- This is specific to ubuntu gcc-4.8, some other distros (ex: CentOS7 have patches to fix this).

 - also updating PatchUtils (script was missing executable bit on Linux and `file(CHMOD)` is `CMake >= 3.19` (not on CentOS7), it felt relevant to simplify), the script was not used.

@biojppm first part of gcc-4.8 support for rapidyaml, second part will be a `compat.cmake` file in rapidyaml + some minor changes.