### PR TITLE
amalgamate: fix encoding issues, handle more characters

### DIFF
--- a/amalgamate_utils.py
+++ b/amalgamate_utils.py
@@ -95,7 +95,7 @@ def catfiles(filenames, rootdir,
             return append_file(entry.filename)
     def append_file(filename, guard=None):
         s = ""
-        with open(filename) as f:
+        with open(filename, encoding="utf8") as f:
             for line in f.readlines():
                 for rx in include_regexes:
                     match = rx.match(line)
@@ -130,7 +130,7 @@ def catfiles(filenames, rootdir,
         elif isinstance(entry, cmtfile):
             filename = f"{rootdir}/{entry.filename}"
             out += banner(entry.filename)
-            with open(filename) as file:
+            with open(filename, encoding="utf8") as file:
                 for line in file.readlines():
                     out += cmtline(line)
         elif isinstance(entry, injcode):
@@ -213,5 +213,5 @@ def file_put_contents(filename: str, contents: str):
         dirname = os.path.dirname(filename)
         if dirname:
             os.makedirs(dirname, exist_ok=True)
-        with open(filename, "w") as output:
+        with open(filename, "w", encoding="utf8") as output:
             output.write(contents)

--- a/amalgamate_utils.py
+++ b/amalgamate_utils.py
@@ -64,6 +64,7 @@ def catfiles(filenames, rootdir,
              definition_macro,
              repo,
              result_incguard):
+    file_re = re.compile('[-./]')
     sepb = "//" + ("**" * 40)
     sepf = "//" + ("--" * 40)
     to_inject = {}
@@ -74,7 +75,7 @@ def catfiles(filenames, rootdir,
         return f"\n\n// (end {repo}/{s})\n"
     def incguard(filename):
         return custom_include_guards.get(filename,
-                                         f"{filename.replace('.','_').replace('/','_').upper()}_")
+                                         f"{file_re.sub('_', filename).upper()}_")
     def replace_include(rx, match, line, guard):
         line = line.rstrip()
         incl = match.group(1)


### PR DESCRIPTION
Small compile script fixes
- Newly added `gcc-4.8.hpp` contains `-` characters that needs to be treated properly
- Some files contains utf8 characters (especially _AUTHORS_), on some containers LC_ALL is not set and Python uses default ascii encoder (failing to read the file).